### PR TITLE
Fix serving the project by removing redundant reference

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,6 @@ import Vue from "vue";
 import App from "./App.vue";
 
 import "./theme.scss";
-import ElementUI from "element-ui";
-Vue.use(ElementUI);
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
It seems you forgot to remove the `ElementUI` reference from `main.js` when you removed `ElementUI` from the project ([f602984](https://github.com/Timmmm/vue_sass_issue/commit/f602984568dadee007033e8d9732f47900e6d4b9)). 

Deleting these lines allows `npm run serve` to run properly.

BTW have you found any solution to the duplicate css issue? 